### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Docker Compose Buildkite Plugin [![Build status](https://badge.buildkite.com/a1d1805d117ec32791cb22055aedc5ff709f1498024295bef0.svg?branch=master)](https://buildkite.com/buildkite/plugins-docker-compose)
 
+This fork of Buildkite's default plugin. It allows for the skipping of build
+steps if an image with the specified tag already exists. This can dramatically
+speed up certain steps such as dependency installs or asset builds if your
+images are tagged with a proper cache key.
+
 A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) that lets you build, run and push build steps using [Docker Compose](https://docs.docker.com/compose/).
 
 * Containers are built, run and linked on demand using Docker Compose

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -5,7 +5,6 @@ image_repository="$(plugin_read_config IMAGE_REPOSITORY)"
 pull_retries="$(plugin_read_config PULL_RETRIES "0")"
 push_retries="$(plugin_read_config PUSH_RETRIES "0")"
 override_file="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
-use_prior_image="$(plugin_read_config USE_PRIOR_IMAGE)"
 build_images=()
 
 service_name_cache_from_var() {


### PR DESCRIPTION
This PR adds a comment to the README explaining how this differs from Buildkite's official plugin.

Our functionality to reduce build times for existing image tags was rejected in https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/pull/310.

